### PR TITLE
Add content to the alert

### DIFF
--- a/miband.py
+++ b/miband.py
@@ -258,7 +258,7 @@ class miband(Peripheral):
             except Empty:
                 break
 
-    def send_custom_alert(self, type, phone):
+    def send_custom_alert(self, type, phone, msg):
         if type == 5:
             base_value = '\x05\x01'
         elif type == 4:
@@ -267,8 +267,10 @@ class miband(Peripheral):
                 base_value = '\x03\x01'
         svc = self.getServiceByUUID(UUIDS.SERVICE_ALERT_NOTIFICATION)
         char = svc.getCharacteristics(UUIDS.CHARACTERISTIC_CUSTOM_ALERT)[0]
-        char.write(bytes(base_value+phone,'utf-8'), withResponse=True)
-
+        # 3 new lines: space for the icon, two spaces for the time HH:MM
+        text = base_value+phone+'\x0a\x0a\x0a'+msg.replace('\\n','\n')
+        char.write(bytes(text,'utf-8'), withResponse=True)
+        
     def get_steps(self):
         char = self.svc_1.getCharacteristics(UUIDS.CHARACTERISTIC_STEPS)[0]
         a = char.read()

--- a/miband.py
+++ b/miband.py
@@ -265,12 +265,14 @@ class miband(Peripheral):
             base_value = '\x04\x01'
         elif type == 3:
                 base_value = '\x03\x01'
+        elif type == 1:
+            base_value = '\x01\x01'
         svc = self.getServiceByUUID(UUIDS.SERVICE_ALERT_NOTIFICATION)
         char = svc.getCharacteristics(UUIDS.CHARACTERISTIC_CUSTOM_ALERT)[0]
         # 3 new lines: space for the icon, two spaces for the time HH:MM
         text = base_value+phone+'\x0a\x0a\x0a'+msg.replace('\\n','\n')
         char.write(bytes(text,'utf-8'), withResponse=True)
-        
+
     def get_steps(self):
         char = self.svc_1.getCharacteristics(UUIDS.CHARACTERISTIC_STEPS)[0]
         a = char.read()

--- a/miband4_console.py
+++ b/miband4_console.py
@@ -96,14 +96,16 @@ def general_info():
 
 
 def send_notif():
-    msg = input ("Enter message or phone number to be displayed: ")
+    title = input ("Enter title or phone number to be displayed: ")
+    print ('Reminder: at Mi Band 4 you have 10 characters per line, and up to 6 lines')
+    msg = input ("Enter optional message to be displayed: ")
     ty= int(input ("1 for Message / 2 for Missed Call / 3 for Call: "))
     if(ty > 3 or ty < 1):
         print ('Invalid choice')
         time.sleep(2)
         return
     a=[5,4,3]
-    band.send_custom_alert(a[ty-1],msg)
+    band.send_custom_alert(a[ty-1],title,msg)
 
 
 # Needs Auth

--- a/miband4_console.py
+++ b/miband4_console.py
@@ -99,12 +99,12 @@ def send_notif():
     title = input ("Enter title or phone number to be displayed: ")
     print ('Reminder: at Mi Band 4 you have 10 characters per line, and up to 6 lines')
     msg = input ("Enter optional message to be displayed: ")
-    ty= int(input ("1 for Message / 2 for Missed Call / 3 for Call: "))
-    if(ty > 3 or ty < 1):
+    ty= int(input ("1 for Mail / 2 for Message / 3 for Missed Call / 4 for Call: "))
+    if(ty > 4 or ty < 1):
         print ('Invalid choice')
         time.sleep(2)
         return
-    a=[5,4,3]
+    a=[1,5,4,3]
     band.send_custom_alert(a[ty-1],title,msg)
 
 
@@ -198,7 +198,7 @@ if __name__ == "__main__":
         
     menu = CursesMenu("MIBand4", "Features marked with @ require Auth Key")
     info_item = FunctionItem("Get general info of the device", general_info)
-    call_item = FunctionItem("Send Call/ Missed Call/Message", send_notif)
+    call_item = FunctionItem("Send Mail/ Call/ Missed Call/ Message", send_notif)
     set_music_item = FunctionItem("Set the band's music and receive music controls", set_music)
     steps_item = FunctionItem("@ Get Steps/Meters/Calories/Fat Burned", get_step_count)
     single_heart_rate_item = FunctionItem("@ Get Heart Rate", get_heart_rate)


### PR DESCRIPTION
Option 3 - Send Call/ Missed Call/ Message
gets the message, and renders it only on the 1st line of the screen, while the band contains more lines.

Now the user can enter also a body and have more data on the screen, which can be also read in the default 5 seconds (otherwise he needs more time to wait for the scroll in case of long message).

For example:
(previously: Enter **message** or phone number to be displayed: )

Enter **title** or phone number to be displayed: _a to z_
Reminder: at Mi Band 4 you have 10 characters per line, and up to 6 lines
Enter optional **message** to be displayed: _the quick\nbrown fox\njumps over\nthe lazy\ndog_
1 for Message / 2 for Missed Call / 3 for Call: 1

and the notification on the band: 

```
<TYPE-ICON> a to z (scrolling)
     00:20
the quick
brown fox
jumps over
the lazy
dog

```

How to correctly enter the new optional message:

given it is '_the quick brown fox jumps over the lazy dog_'

break it to 10 characters with new-line character

```
  0123456789
  the quick\n
  brown fox\n
  jumps over\n
  the lazy\n
  dog

```
and re-concatenate it to be: _the quick\nbrown fox\njumps over\nthe lazy\ndog_
this is the input for this excellent utility.

### TODOs ###

1. Make the break to new lines automatically, but it's a different story.
2. Instead of 3 lines of space, put only 2 in case the user provides 7 lines (title+2 spaces+7 lines=10)

