### PR TITLE
Update README.md to add sudo in installing the requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ On a **non rooted phone** you may consider using https://www.freemyband.com/
 
     ```
     sudo apt-get install libglib2.0-dev
-    pip3 install -r requirements.txt
+    sudo pip3 install -r requirements.txt
     ```
 2. (**Optional**) Find AuthKey for your device and put it to `auth_key.txt` file in the current directory with the script. 
 


### PR DESCRIPTION
It took me a while before I finally figured it out. If I simply type `pip3 install -r requirements.txt` without `sudo`, then it will simply say "Requirement already satisfied" for all the requirements. But, if I add `sudo`, it will actually install them.

It took me several hours to figure out what's the problem.