### PR TITLE
Allow configuring/reordering the band display

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -101,3 +101,16 @@ class Weekdays(object):
     saturday  = 0x01 << 5
     sunday    = 0x01 << 6
     everyday  = 0x01 << 7
+    
+class DISPLAY_ITEMS(object):
+    
+    __metaclass__ = Immutable
+    STATUS = 0x01
+    HEART_RATE = 0x02
+    WORKOUT = 0x03
+    WEATHER = 0x04
+    MI_HOME = 0x05 # I have no clue what this does. Pressing it does nothing for me
+    NOTIFICATIONS = 0x06
+    MORE = 0x07 # While the app doesn't allow you to remove this, I tried and it works perfectly
+    
+    ALL_ITEMS = [STATUS, HEART_RATE, WORKOUT, WEATHER, NOTIFICATIONS, MORE]

--- a/miband.py
+++ b/miband.py
@@ -694,7 +694,7 @@ class miband(Peripheral):
         if any(i for i in included_display_items if i not in DISPLAY_ITEMS.ALL_ITEMS):
             print("Some of those display items are not valid")
             return
-  
+
         excluded_display_items = [i for i in DISPLAY_ITEMS.ALL_ITEMS if i not in included_display_items]
 
         included_display_items.insert(0, 0x12) # 0x12 is the band homescreen

--- a/miband.py
+++ b/miband.py
@@ -694,16 +694,24 @@ class miband(Peripheral):
         if any(i for i in included_display_items if i not in DISPLAY_ITEMS.ALL_ITEMS):
             print("Some of those display items are not valid")
             return
-        
+  
         excluded_display_items = [i for i in DISPLAY_ITEMS.ALL_ITEMS if i not in included_display_items]
-        
+
         included_display_items.insert(0, 0x12) # 0x12 is the band homescreen
-        
+
         num_included = len(included_display_items)
-        
+
+        # The format for the band display has a 1e for a constant header, and 4 bytes for each display item
+        # i is the item index and d is the display item ID (look in constants.py)
+        # The included items always show up before the excluded (hidden) items, and are as follows:
+        # <i> 00 ff <d>
+        # The excluded items are as follows:
+        # <i> 01 ff <d>
+        # So including only the homescreen and "more" display item would be like this
+        # 1e  00 00 ff 12  01 00 ff 07  02 01 ff 01  03 01 ff 02  04 01 ff 03  05 01 ff 04  06 01 ff 06
+
         included_bytes = [byte for i, d in enumerate(included_display_items) for byte in [i, 0, 0xff, d]]
         excluded_bytes = [byte for i, d in enumerate(excluded_display_items) for byte in [i + num_included, 1, 0xff, d]]
-        
+
         buf = bytes([0x1e, *included_bytes, *excluded_bytes])
         self.writeChunked(2, buf)
-        


### PR DESCRIPTION
First, I wanted to let you know how helpful this library has been to me! The work you (and the many other people involved in this Mi Band community) have done is really amazing.

This allows configuring what items show on the band display

Usage:
```python
from constants import DISPLAY_ITEMS

band.setBandDisplay(DISPLAY_ITEMS.ALL_ITEMS) # Show every item except MI Home
band.setBandDisplay([DISPLAY_ITEMS.WORKOUT, DISPLAY_ITEMS.STATUS, DISPLAY_ITEMS.MORE, DISPLAY_ITEMS.HEART_RATE]) # Display those items in that order
```
https://github.com/satcar77/miband4/blob/97e13678d07e66942a1028c72d61140f850d35af/constants.py#L108-L114

When I was looking at the BT Packets, I noticed that the app was always skipping over the display item with ID 5. When I tried making that display item visible, I got something called "Mi Home". Maybe that's a HA thing they have that's not there by default.

I'm working on adding weather support!